### PR TITLE
Demonstrate issue with fixed identity partitioning

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -52,7 +52,9 @@ public class TableTestBase {
   // Schema passed to create tables
   public static final Schema SCHEMA =
       new Schema(
-          required(3, "id", Types.IntegerType.get()), required(4, "data", Types.StringType.get()));
+          required(3, "id", Types.IntegerType.get()),
+          required(4, "data", Types.StringType.get()),
+          required(5, "fixed", Types.FixedType.ofLength(4)));
 
   protected static final int BUCKETS_NUMBER = 16;
 

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -60,20 +60,20 @@ public class TableTestBase {
 
   // Partition spec used to create tables
   public static final PartitionSpec SPEC =
-      PartitionSpec.builderFor(SCHEMA).bucket("data", BUCKETS_NUMBER).build();
+      PartitionSpec.builderFor(SCHEMA).bucket("data", BUCKETS_NUMBER).identity("fixed").build();
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
           .withPath("/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=0/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_A2 =
       DataFiles.builder(SPEC)
           .withPath("/path/to/data-a-2.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=0/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DeleteFile FILE_A_DELETES =
@@ -81,7 +81,7 @@ public class TableTestBase {
           .ofPositionDeletes()
           .withPath("/path/to/data-a-deletes.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=0/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   // Equality delete files.
@@ -90,14 +90,14 @@ public class TableTestBase {
           .ofEqualityDeletes(1)
           .withPath("/path/to/data-a2-deletes.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=0")
+          .withPartitionPath("data_bucket=0/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
           .withPath("/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=1") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=1/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .withSplitOffsets(ImmutableList.of(1L))
           .build();
@@ -106,14 +106,14 @@ public class TableTestBase {
           .ofPositionDeletes()
           .withPath("/path/to/data-b-deletes.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=1") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=1/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
           .withPath("/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=2") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=2/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .withSplitOffsets(ImmutableList.of(2L, 8L))
           .build();
@@ -122,14 +122,14 @@ public class TableTestBase {
           .ofEqualityDeletes(1)
           .withPath("/path/to/data-c-deletes.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=2") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=2/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
           .withPath("/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=3/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .withSplitOffsets(ImmutableList.of(0L, 3L, 6L))
           .build();
@@ -138,7 +138,7 @@ public class TableTestBase {
           .ofEqualityDeletes(1)
           .withPath("/path/to/data-d-deletes.parquet")
           .withFileSizeInBytes(10)
-          .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+          .withPartitionPath("data_bucket=3/fixed=abcd") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_WITH_STATS =

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriter.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriter.java
@@ -132,11 +132,11 @@ public class TestManifestWriter extends TableTestBase {
     Assert.assertFalse("contains_nan should be false", partitionFieldSummary.containsNaN());
     Assert.assertEquals(
         "Lower bound should match",
-        Integer.valueOf(1),
+        Integer.valueOf(0),
         Conversions.fromByteBuffer(Types.IntegerType.get(), partitionFieldSummary.lowerBound()));
     Assert.assertEquals(
         "Upper bound should match",
-        Integer.valueOf(3),
+        Integer.valueOf(10),
         Conversions.fromByteBuffer(Types.IntegerType.get(), partitionFieldSummary.upperBound()));
   }
 


### PR DESCRIPTION
This modifies TestManifestWriter to write out partition values for identity-partitioning over a `fixed` column. The modified test crashes with exception:

```
java.lang.ClassCastException: class java.nio.HeapByteBuffer cannot be cast to class org.apache.avro.generic.GenericData$Fixed (java.nio.HeapByteBuffer is in module java.base of loader 'bootstrap'; org.apache.avro.generic.GenericData$Fixed is in unnamed module of loader 'app')
org.apache.avro.file.DataFileWriter$AppendWriteException: java.lang.ClassCastException: class java.nio.HeapByteBuffer cannot be cast to class org.apache.avro.generic.GenericData$Fixed (java.nio.HeapByteBuffer is in module java.base of loader 'bootstrap'; org.apache.avro.generic.GenericData$Fixed is in unnamed module of loader 'app')
	at app//org.apache.avro.file.DataFileWriter.append(DataFileWriter.java:317)
	at app//org.apache.iceberg.avro.AvroFileAppender.add(AvroFileAppender.java:66)
	at app//org.apache.iceberg.ManifestWriter.addEntry(ManifestWriter.java:97)
	at app//org.apache.iceberg.TableTestBase.writeManifest(TableTestBase.java:289)
	at app//org.apache.iceberg.TableTestBase.writeManifest(TableTestBase.java:262)
	at app//org.apache.iceberg.TestManifestWriter.testManifestPartitionStats(TestManifestWriter.java:86)
```

I'm not sure if this is a bug, or if I'm doing something wrong when constructing the `PartitionKey` (see `makePartitionKeyForRow`).